### PR TITLE
Removed clean from grunt build

### DIFF
--- a/client/gruntFile.js
+++ b/client/gruntFile.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
 
   // Default task.
   grunt.registerTask('default', ['jshint','build','karma:unit']);
-  grunt.registerTask('build', ['clean','html2js','concat',/*'recess:build',*/'copy:assets']);
+  grunt.registerTask('build', ['html2js','concat',/*'recess:build',*/'copy:assets']);
   grunt.registerTask('release', ['clean','html2js','uglify','jshint','karma:unit','concat:index', 'recess:min','copy:assets']);
   grunt.registerTask('test-watch', ['karma:watch']);
 


### PR DESCRIPTION
Removed clean from grunt build so that libs under Bower control do not get deleted.