### PR TITLE
sucheta removed from food committee

### DIFF
--- a/server/data/event.json
+++ b/server/data/event.json
@@ -232,7 +232,7 @@
          "committeeMembers":{
             "foodCommittee":{
                "htmlLabel":"Food Committee",
-               "members":"Suronita Dasbiswas,Sucheta Mukherjee,Soma Pradhan,Manisha Prasad,Poulami Saha"
+               "members":"Suronita Dasbiswas,Soma Pradhan,Manisha Prasad,Poulami Saha"
             },
             "culturalCommittee":{
                "htmlLabel":"Cultural Committee",


### PR DESCRIPTION
Due to unavailability, Sucheta is removed from food committee for PB event.